### PR TITLE
Modified translator to ignore SLO and missing scope errors

### DIFF
--- a/nebulous/ems-nebulous/src/main/java/eu/nebulous/ems/translate/NebulousEmsTranslator.java
+++ b/nebulous/ems-nebulous/src/main/java/eu/nebulous/ems/translate/NebulousEmsTranslator.java
@@ -196,11 +196,12 @@ public class NebulousEmsTranslator implements Translator, InitializingBean {
 		}
 
 		// -- Schematron Validation -------------------------------------------
-		log.debug("NebulousEmsTranslator.translate(): Validating metric model: {}", modelName);
+		//XXX:TODO: Replace with a JsonSchema validator
+		/*log.debug("NebulousEmsTranslator.translate(): Validating metric model: {}", modelName);
 		if (!properties.isSkipModelValidation()) {
 			validator.validateModel(modelObj, modelName);
 			log.debug("MetricModelAnalyzer.analyzeModel(): Metric model is valid: {}", modelName);
-		}
+		}*/
 
 		// -- Analyze metric model --------------------------------------------
 		log.debug("NebulousEmsTranslator.translate():  Analyzing model...");

--- a/nebulous/ems-nebulous/src/main/java/eu/nebulous/ems/translate/analyze/AnalysisUtils.java
+++ b/nebulous/ems-nebulous/src/main/java/eu/nebulous/ems/translate/analyze/AnalysisUtils.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Service;
 
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -69,6 +70,30 @@ public class AnalysisUtils implements InitializingBean {
         if (o instanceof Map m) return m;
         log.error("AnalysisUtils.asMap: input: {}", o);
         throw createException("Object is not a Map: "+o);
+    }
+
+    static boolean isList(Object o) {
+        return (o instanceof List);
+    }
+
+    static boolean isMap(Object o) {
+        return (o instanceof Map);
+    }
+
+    static boolean isNullOrEmpty(Object o) {
+        if (o instanceof Collection c)
+            return isNullOrEmpty(c);
+        if (o instanceof Map m)
+            return isNullOrEmpty(m);
+        return (o==null);
+    }
+
+    static boolean isNullOrEmpty(Collection c) {
+        return (c==null || c.isEmpty());
+    }
+
+    static boolean isNullOrEmpty(Map m) {
+        return (m==null || m.isEmpty());
     }
 
     // ------------------------------------------------------------------------

--- a/nebulous/ems-nebulous/src/main/java/eu/nebulous/ems/translate/analyze/NodeUpdatingHelper.java
+++ b/nebulous/ems-nebulous/src/main/java/eu/nebulous/ems/translate/analyze/NodeUpdatingHelper.java
@@ -74,6 +74,10 @@ class NodeUpdatingHelper extends AbstractHelper {
     }
 
     Map<String, Set<String>> createComponentsToScopesMap(DocumentContext ctx, Set<String> componentNames) {
+        Map specs = ctx.read("$.spec", Map.class);
+        if (isNullOrEmpty(specs.get("scopes")))
+            return Collections.emptyMap();
+
         Map<String, Set<String>> componentToScopeMap = new LinkedHashMap<>();
         ctx.read("$.spec.scopes.*", List.class).stream().filter(Objects::nonNull).forEach(scope -> {
             // Get scope name and scope components
@@ -107,6 +111,10 @@ class NodeUpdatingHelper extends AbstractHelper {
     }
 
     Map<String, Set<String>> createScopesToComponentsMap(DocumentContext ctx, Set<String> componentNames) {
+        Map specs = ctx.read("$.spec", Map.class);
+        if (isNullOrEmpty(specs.get("scopes")))
+            return Collections.emptyMap();
+
         Map<String, Set<String>> scopeToComponentMap = new LinkedHashMap<>();
         ctx.read("$.spec.scopes.*", List.class).stream().filter(Objects::nonNull).forEach(scope -> {
             // Get scope name and scope components


### PR DESCRIPTION
Modified translator ignore (rather than throw exceptions) when: (a) an SLO contains an empty constraint, (b) the 'spec.scopes' section in a metric model is missing. Also commented out the metric model validator.